### PR TITLE
Fix `strscan` rspec error on `ruby-head`

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -33,7 +33,7 @@ jobs:
           bundle install --jobs 4 --retry 3
 
       - name: Rspec
-        run: rspec --pattern "spec/**/unit/*_spec.rb"
+        run: bundle exec rspec --pattern "spec/**/unit/*_spec.rb"
 
       - name: RuboCop
         run: bundle exec rubocop

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,3 +6,7 @@
 
 * Add `ruby-3.3` to CI
 * Add `dependabot` check for `GitHub Actions`
+
+### Fixes
+
+* Fix `strscan` gem activation error in CI

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,4 +125,4 @@ DEPENDENCIES
   rubocop-rspec
 
 BUNDLED WITH
-   2.5.3
+   2.5.11


### PR DESCRIPTION
The error is:
```
  You have already activated strscan 3.1.1, but your Gemfile requires strscan 3.1.0. Since strscan is a default gem, you can either remove your dependency on it or try updating to a newer version of bundler that supports strscan as a default gem.
```

See:
https://github.com/ONLYOFFICE-QA/onlyoffice-droplets-starter/actions/runs/9315350446/job/25641314356?pr=280